### PR TITLE
Fix Some issues from June 8 crit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,12 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
+    google-protobuf (3.22.2-arm64-darwin)
     google-protobuf (3.22.2-x64-mingw-ucrt)
+    google-protobuf (3.22.2-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -53,7 +56,11 @@ GEM
     rexml (3.2.5)
     rouge (4.1.0)
     safe_yaml (1.0.5)
+    sass-embedded (1.59.3-arm64-darwin)
+      google-protobuf (~> 3.21)
     sass-embedded (1.59.3-x64-mingw-ucrt)
+      google-protobuf (~> 3.21)
+    sass-embedded (1.59.3-x86_64-linux-gnu)
       google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -61,6 +68,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin-22
   x64-mingw-ucrt
   x86_64-linux
 

--- a/_data/config-browse.csv
+++ b/_data/config-browse.csv
@@ -1,9 +1,8 @@
 field,display_name,btn,hidden,sort_name
 date,Date,,,Date
 creator,Creator,,,
-subject,,true
-location,,true
-identifier,,,true,Identifier
-people,,true
-places,,true
-organizations,,true
+subject,,true,true
+location,,true,true
+people,,true,true
+places,,true,true
+organizations,,true,true

--- a/_includes/collection-nav.html
+++ b/_includes/collection-nav.html
@@ -16,7 +16,7 @@
                 {% for nav in navItems %}
                 {% if nav.stub %}
                 <li class="nav-item">
-                    <a class="nav-link{% if page.url == nav.stub %} active{% endif %}" href="{{ nav.stub | relative_url }}">{{ nav.display_name }}</a>
+                    <a class="nav-link{% if page.url == nav.stub %} active{% endif %}" href="{{ nav.stub | relative_url }}" {% if nav.stub contains 'http' %}target="_blank"{% endif %}>{{ nav.display_name }}{% if nav.stub contains 'http' %}<sup> {% include feature/icon.html icon="box-arrow-up-right" label="External Link" %}</sup>{% endif %}</a>
                 </li>
                 {%- else -%}
                 <li class="nav-item dropdown">
@@ -25,7 +25,7 @@
                     <a class="nav-link  dropdown-toggle{% if childStubs contains page.url %} active{% endif %}" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ nav.display_name }}</a>
                     <div class="dropdown-menu">
                         {% for c in navChildren %}
-                        <a class="dropdown-item {% if page.url == c.stub %}active{% endif %}" href="{{ c.stub | relative_url }}">{{ c.display_name }}</a>
+                        <a class="dropdown-item {% if page.url == c.stub %}active{% endif %}" href="{{ c.stub | relative_url }}" {% if c.stub contains 'http' %}target="_blank"{% endif %}>{{ c.display_name }}{% if c.stub contains 'http' %}<sup>{% include feature/icon.html icon="box-arrow-up-right" label="External Link" %}</sup>{% endif %}</a>
                         {% endfor %}
                     </div>
                 </li>

--- a/_includes/index/carousel.html
+++ b/_includes/index/carousel.html
@@ -24,7 +24,8 @@
 {% if include.carousel-type == "small" %}
 {%- assign carousel-items = site.data[site.metadata] | where_exp: 'item','item.objectid' | where_exp: "item","item.image_small" -%}
 {% else %}
-{%- assign carousel-items = site.data[site.metadata] | where_exp: 'item','item.objectid' | where_exp: "item","item.image_thumb" -%}
+{%- assign carousel-items = site.data[site.metadata] | where_exp: 'item','item.objectid' | where_exp: "item","item.image_thumb" | where_exp: 'item','item.display_template == "transcript"' -%}
+
 {% endif %}
 
 {%- comment -%}

--- a/_layouts/item/transcript.html
+++ b/_layouts/item/transcript.html
@@ -39,7 +39,7 @@ endcapture -%}
           data-bs-toggle="modal" data-bs-target="#bio-modal">Click for bio</a>{% endif %}</h2>
       {% if page.bio %}{% include transcript/item/bio-modal.html %}{% endif %}
       <p class="meta">{%if page.description%}<span class="me-3"><b>Description:</b>  {{page.description}}</span>{%endif%}{%if
-        page.date%}<b>Date:</b> {{page.date | date: "%B %d, %Y" }}{%endif%}
+        page.date%}<br><b>Date:</b> {{page.date | date: "%B %d, %Y" }}{%endif%}
         {%if page.interviewer %} <br><b>Interviewer:</b> {{page.interviewer}}{%endif%}</p>
       {% include transcript/item/download-buttons.html %}
       {% include transcript/item/metadata-modal.html %}
@@ -47,7 +47,8 @@ endcapture -%}
     </div>
     {% if page.image_small or page.image_thumb %}
     <div class="col-md-3 meta{% if av == 'vimeo' or av == 'youtube'%} d-none d-md-block{% endif %}">
-     <!-- IMAGE WASN'T WORKING <img class="img-thumbnail timeline-thumb" src="{{page.image_small | default: page.image_thumb }}" alt="{page.title}"> -->
+      <img class="img-thumbnail timeline-thumb" src="{{page.image_small | default: page.image_thumb | relative_url }}" alt="{{page.title}}"> 
+
     </div>
     {% endif %}
   </div>
@@ -56,8 +57,8 @@ endcapture -%}
     {% include
     transcript/player/{{av}}.html %}
   </div>{% endif %}
-  {% if site.data.filters %}
-  <div class="vizdiv">
+  
+  <div class="vizdiv {% unless site.data.filters %}d-none{% endunless%}">
     <h3 class="mt-3 mb-0 meta">Topics:</h3>
     <svg id="colorViz" class="chart" width="100%" height="100px" style="overflow: visible">
       {% for item in items %}
@@ -67,7 +68,7 @@ endcapture -%}
       <a  onclick="scrollToLine('{{-forloop.index-}}');">
         <rect id="rect{{-forloop.index-}}" x="{{forloop.index0 | times: rect-width }}%" y="20" width="{{rect-width}}%" height="50" data-bs-toggle="tooltip" data-placement="top" class="{%- assign tags = item.tags | split: ";" | compact | where_exp: 'item', 'item != " "' %}{% for tag in tags %}{{tag | slugify }} {% endfor %}" data-bs-title="{{ item.words }}{% if item.tags %}(Subjects: {{ item.tags | replace: ';', ', ' }}){%endif%}"></rect>
       </a>{%endfor%}</svg>
-  </div>{% endif %}
+  </div>
 </div>
 <div id="filters-content" class="pe-md-5">
   <div class="row my-3 sticky-top bg-white border-bottom border-left border-right d-print-none py-3 w-md-75"
@@ -119,7 +120,7 @@ endcapture -%}
     {% assign prev_index = forloop.index0 | times: 1 | minus: 1 %}
     {% assign prev_speaker = items[prev_index].speaker %}
     {% assign mod = forloop.index | plus: 1 | modulo: 5 %}
-    <div id="{{page.objectid}}{{ forloop.index }}" class="{%- assign tags = item.tags | split: ";" | compact | where_exp: 'item' , 'item != " "' %}{% for tag in tags %}{{tag | slugify }} {% endfor %} row line my-1">
+    <div id="{{page.objectid}}{{ forloop.index }}" class="{%- assign tags = item.tags | split: ";" | compact | where_exp: 'item' , 'item != " "' %}{% for tag in tags %}{{tag | slugify }} {% endfor %}row line my-1">
       <p class="words col-md-10 col-lg-8 col-print-12 pr-0">
         {% unless item.speaker == prev_speaker %}{%if item.speaker %}<span class="fw-bold pe-3 pb-3">{{item.speaker | remove: ":"}}:</span>{% endif %}{% endunless %}{{item.words}}
       </p>


### PR DESCRIPTION
- search is now working
- removed buttons from browse cards by adding "true" to the hidden value in the _data/config-nav.csv for those lines that are buttons. (If you want them back, just delete the second true in the line)
- Made the external link in the nav open in a new tab
- just included oral histories in the carousel on the home page
- I also updated gemfile.lock so you might need to run `bundle install` when you start up your local machine again. 